### PR TITLE
Fixed executable name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python build.py
 
 ## Usage
 
-Inside the folder `build` there is the executable `Tokenizer`, 
+Inside the folder `build` there is the executable `tokenizer`, 
 you can pass any string as argument.
 
 *Example:*


### PR DESCRIPTION
Fixed a typo to clarify the example guide. 